### PR TITLE
Correction de la licence

### DIFF
--- a/src/KG/BeekeepingManagementBundle/Resources/views/Colonie/diviser.html.twig
+++ b/src/KG/BeekeepingManagementBundle/Resources/views/Colonie/diviser.html.twig
@@ -3,7 +3,7 @@
  
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 4 of the License, or
+  the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
  
   This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
La licence de ce fichier source indiquait GPLv4 qui n'existe pas à ce jour. C'est l'unique fichier source impacté par ce problème.
Cette PR corrige en GPLv3 comme le reste du projet.
