### PR TITLE
mise à jour des cgu passage de Kevin à openbeelab

### DIFF
--- a/src/KG/SiteBundle/Resources/views/Accueil/cgu.html.twig
+++ b/src/KG/SiteBundle/Resources/views/Accueil/cgu.html.twig
@@ -73,10 +73,12 @@
 
                                             <h3>Article 2 : Mentions légales</h3>
                                             <p>
-                                                L'édition et la publication du site OpenHiveManager est assurée par l'auto-entrepreneur <a title="CV Kévin Grenèche" href="http://www.doyoubuzz.com/kevin-greneche">Kévin Grenèche</a> dont le siège social est situé au 16 impasse de Borderouge 31200 Toulouse FRANCE.
+                                                L'édition et la publication du site OpenHiveManager est assurée par le groupe openbeelab de l'association cPlusMoins <a title="CplusMoins" href="http://cplusmoins.org">CplusMoins</a> située au 13 rue Charles Domercq 33800 Bordeaux FRANCE.
                                             </p>
+					    <p>
+						Le site a été créé par Kevin Grenèche en licences libres et la gestion de ce bien commun a été léguée par son créateur au groupe openbeelab en 2017.
                                             <p>
-                                                L'hébergeur du site OpenHiveManager est l'association <a title="Web4all" href="http://web4all.fr">Web4all</a> dont le siège social est situé au 161 boulevard Charles de Gaulle 92700 Colombes FRANCE.                
+                                                L'hébergeur du site OpenHiveManager est le FAI associatif <a title="Aquilenet" href="https://aquilenet.fr.fr">Aquilenet</a> membre de la fédération FDN, et dont le siège social est situé à Bordeaux, FRANCE.                
                                             </p>    
 
                                             <h3>Article 3 : Définitions</h3>
@@ -110,7 +112,7 @@
                                                     <li>Une partie applicative, qui englobe toutes les pages situées sous le répertoire "manager", correspondant à l'application de gestion apicole.</li>
                                                     <li>Une partie informative, qui regroupe le reste des pages du site</li>
                                                 </ul>  
-                                                La partie applicative est publiée sous <a title="GNU GPLv3" href="https://www.gnu.org/licenses/quick-guide-gplv3.html">licence GNU GPLv3</a> et son code source est situé <a title="Code source OpenHiveManager" href="https://git.framasoft.org/jack12/OpenHiveManager.git">ici</a>.<br />
+                                                La partie applicative est publiée sous <a title="GNU GPLv3" href="https://www.gnu.org/licenses/quick-guide-gplv3.html">licence GNU GPLv3</a> et son code source est situé <a title="Code source OpenHiveManager" href="https://github.com/Jack12FR/OpenHiveManager">ici</a>.<br />
                                                 La partie informative est mise à disposition selon les termes de la <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/">licence Creative Commons Attribution - Pas d&#39;Utilisation Commerciale - Pas de Modification 4.0 International</a>.
                                             </p>
                                             <p>


### PR DESCRIPTION
- rectification de l'adresse de dépot git du code (ticket: https://github.com/Jack12FR/OpenHiveManager/issues/3)
- passage de relais d'éditeur de Kevin à openbeelab et d'hébergeur de web4all à aquilenet 